### PR TITLE
added styling for railways w/ service=yard tag fixes #103

### DIFF
--- a/hdm.mml
+++ b/hdm.mml
@@ -657,7 +657,7 @@
         "port": "5432",
         "project": "hdm",
         "srs": null,
-        "table": "( SELECT way, tunnel, bridge, railway, CASE WHEN railway='rail' THEN 'main' ELSE 'other' END AS type FROM planet_osm_line WHERE railway IS NOT NULL ORDER BY z_order) AS data",
+        "table": "( SELECT way, tunnel, bridge, railway, service, CASE WHEN service='yard' THEN 'yard' WHEN railway='rail' THEN 'main' ELSE 'other' END AS type FROM planet_osm_line WHERE railway IS NOT NULL ORDER BY z_order) AS data",
         "type": "postgis",
         "extent": "-20037508,-19929239,20037508,19929239",
         "user": "osm"

--- a/roads.mss
+++ b/roads.mss
@@ -416,6 +416,16 @@ as well. */
   [zoom>=18] { line-width: 4; }
 }
 
+#railway[type='yard'][zoom>=12][zoom<=20] {
+  line-cap: butt;
+  line-color: @rail_line;
+  [zoom>=12] { line-width: 0.25; }
+  [zoom>=14] { line-width: 0.35; }
+  [zoom>=15] { line-width: 0.75; }
+  [zoom>=16] { line-width: 1.5; }
+  [zoom>=18] { line-width: 2.25; }
+}
+
 #railway[type='main'][zoom>=12][zoom<=20] {
   ::outline {
     line-cap: butt;


### PR DESCRIPTION
fixes #103 

added styling for railways that have the service=yard tag. black blobs are no more in places like: http://umap.fluv.io/en/map/hdm-first-draft_728#14/18.5033/-69.8923
