### PR TITLE
update URL on the compare.html to OSM-FR server

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -29,7 +29,7 @@
 <script>
 var startPoint = [19.6718, -72.1304];
 var mapHDM = L.map('map-hdm', {zoomControl:false}).setView(startPoint, 13);
-L.tileLayer('http://a.layers.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20}).addTo(mapHDM);
+L.tileLayer('http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20}).addTo(mapHDM);
 var map2U = L.map('map-2u', {zoomControl: false,editInOSMControl:true}).setView(startPoint, 13);
 L.tileLayer('http://{s}.layers.openstreetmap.fr/2u/{z}/{x}/{y}.png', {maxZoom: 20}).addTo(map2U);
 var hashHDM = new L.Hash(mapHDM);


### PR DESCRIPTION
While preparing for the presentation (and making GIFs of comparisons between maps), I noticed the tile URL in compare.html was on your own server, fluv, the old home of the HDM tiles. ;) 

Unimportant, but thought to push this because I was making this change anyways. 
