### PR TITLE
corrected sql to select waterways w/ seasonal or intermittent tags [ref #105]

### DIFF
--- a/hdm.mml
+++ b/hdm.mml
@@ -276,7 +276,7 @@
         "key_field": "",
         "password": "osm",
         "port": "5432",
-        "table": "( SELECT way, waterway AS type, CASE WHEN tags->'seasonal'='yes' OR tags->'intermittent'='yes' THEN 'yes' ELSE 'no' END AS seasonal FROM planet_osm_line WHERE waterway IN ('river', 'canal', 'stream', 'ditch', 'drain')) AS data",
+        "table": "( SELECT way, waterway AS type,\nCASE WHEN intermittent IN ('yes') OR tags@> hstore('seasonal','yes') THEN 'yes'\nELSE 'no' END AS seasonal\nFROM planet_osm_line\nWHERE waterway IN ('river', 'canal', 'stream', 'ditch', 'drain')) as h2o",
         "type": "postgis",
         "extent": "-20037508,-19929239,20037508,19929239",
         "user": "osm"


### PR DESCRIPTION
query now selects waterway that have intermittent=yes or seasonal=yes tag. 
Feel free to merge this; I'll make a new, separate branch to tweak the styling. Keep issue #105 open until the styling is added. 

yes is the value for 90% of seasonal=\* tags; and 99% of intermittent=\* tags. Query can be adjusted later on for other values if desired.  
