### PR TITLE
change coastlines to OSMD data sources, fix #121

### DIFF
--- a/base.mss
+++ b/base.mss
@@ -13,8 +13,7 @@
 /* LANDUSE & LANDCOVER
 /* ================================================================== */
 
-#land-low[zoom>=0][zoom<6],
-#land-mid[zoom>=6][zoom<10],
+#land-low[zoom>=0][zoom<10],
 #land-high[zoom>=10] {
   polygon-fill: @land;
   polygon-gamma: 0.75;

--- a/hdm.mml
+++ b/hdm.mml
@@ -26,7 +26,7 @@
   "Layer": [
     {
       "Datasource": {
-        "file": "http://mapbox-geodata.s3.amazonaws.com/natural-earth-1.3.0/physical/10m-land.zip"
+        "file": "http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip"
       },
       "class": "shp",
       "geometry": "polygon",
@@ -43,7 +43,7 @@
     },
     {
       "Datasource": {
-        "file": "http://tilemill-data.s3.amazonaws.com/osm/coastline-good.zip"
+        "file": "http://data.openstreetmapdata.com/land-polygons-split-3857.zip"
       },
       "class": "shp",
       "geometry": "polygon",
@@ -55,23 +55,6 @@
       ],
       "id": "land-high",
       "name": "land-high",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "srs-name": "900913"
-    },
-    {
-      "Datasource": {
-        "file": "http://tilemill-data.s3.amazonaws.com/osm/shoreline_300.zip"
-      },
-      "class": "shp",
-      "geometry": "polygon",
-      "extent": [
-        -179.99999692067183,
-        -84.96651228427099,
-        179.99999692067183,
-        84.96651228427098
-      ],
-      "id": "land-mid",
-      "name": "land-mid",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "srs-name": "900913"
     },


### PR DESCRIPTION
HDM and osm-bright both use the same sources for coastline and water (but with different layer names), share the same styling for water at zoom levels below 10, and have the same issues (The Great Lakes does not render before zoom level 7 and the files are no longer updated and are outdated)

My pull requests for HDM and in osm-bright fixes both issues.

Before my pull request: 
for zoom: >=0 <6 
HDM & bright both use: http://mapbox-geodata.s3.amazonaws.com/natural-earth-1.3.0/physical/10m-land.zip (natural earth 1.3.0)
now known in natural earth >2.0.0: as ne_10m_land_scale_rank.zip
previously known in natural earth as NE_10M_LAND.zip  (ref: https://github.com/nvkelso/natural-earth-vector/blob/master/CHANGELOG)
HDM layer name: land-low
BRight layer's name "land"

at zoom >=6 <10: 
HDM & bright both use: http://tilemill-data.s3.amazonaws.com/osm/shoreline_300.zip
hdm layer name is land-mid
bright layer name is shoreline_300

at >=10: 
HDM & bright use: http://tilemill-data.s3.amazonaws.com/osm/coastline-good.zip"
HDM layer name: is land-high
bright layer name is: processed_p 

Instead, I propose to use 2 files from openstreetmapdata.com that are also used in openstreetmap-carto.
- simplified land polygons at lower zoom levels and split land polygons at higher zooms. 

openstreetmap-carto simply uses 2 files: 

for zoom <10: 
http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip

The simplified land polygon file includes nice detail even though it's simplified, for example, the Great Lakes at Zoom 7:
![osm-cartoz7](https://f.cloud.github.com/assets/955351/1646810/a8909692-5928-11e3-8e4a-5dc502b0d6a4.png)

for >10: 
openstreetmap-carto uses: 
http://data.openstreetmapdata.com/land-polygons-split-3857.zip
(named in osm-carto as coast-poly)

I do have a couple questions and concerns: 
1. HDM and bright have 2 layers (water_gen1 and water_gen0) https://github.com/mapbox/osm-bright/blob/master/osm-bright/osm-bright.osm2pgsql.mml#L163 for creating water at low zoom levels: 

https://github.com/hotosm/HDM-CartoCSS/blob/master/base.mss#L202 

In both layers, water objects whose area is larger than 1,000 or 10,000 are selected and there may be some instances of where water is being drawn in these layers over the existing map-background, water. 

For what it's worth, openstreetmap-carto also likely has instances where it draws water over map-background's water since it starts rendering water from its sql query at z6: https://github.com/gravitystorm/openstreetmap-carto/blob/master/water.mss#L28, regardless of the area. 

As I think about it, I think it's inevitable that there will be instances of water drawn over water and as long as it doesn't hamper performance, we should use the OSMD sources.

Aside, this means the Great Lakes aren't rendered as water at 2 opportunities: 
1. The old natural earth SHP used at zoom >=0 <6 in bright/HDM treats the great lakes as land; 
2. Since the great lakes are tagged natural=coastline, the water_Gen0 query does not select the Great Lakes. 

Other concerns: 
1. The openstreetmapdata.com files are usually updated daily. This can be troublesome for lower bandwidth users as tilemill will automatically download the newer file in the background. @yohanboniface: Do we want to use a script as mentioned in https://github.com/hotosm/HDM-CartoCSS/issues/121 ? 
2. As @Ajashton [mentioned](https://github.com/mapbox/osm-bright/issues/71#issuecomment-20706311), the zip files from openstreetmapdata are not indexed in shapefile. 
   Will this hamper speed? 
