### PR TITLE
fix urls to osm polygons layers, fix #320

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -48,7 +48,7 @@ Stylesheet:
 
 Layer:
   - Datasource:
-      file: http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip
+      file: https://osmdata.openstreetmap.de/download/simplified-land-polygons-complete-3857.zip
       type: shape
     class: shp
     geometry: polygon
@@ -57,7 +57,7 @@ Layer:
 
   - id: land-high
     Datasource:
-      file: http://data.openstreetmapdata.com/land-polygons-split-3857.zip
+      file: https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip
       type: shape
     class: shp
     geometry: polygon


### PR DESCRIPTION

Read https://github.com/hotosm/HDM-CartoCSS/issues/320 for more context. 

I was able to compare the old shapefiles (I already had them downloaded) and these new files in QGIS and they appear to be the same and use the same projection, 3857. 

